### PR TITLE
remove bucket acl

### DIFF
--- a/s3-content-bucket.tf
+++ b/s3-content-bucket.tf
@@ -1,8 +1,3 @@
-resource "aws_s3_bucket_acl" "s3_bucket_acl" {
-  bucket = aws_s3_bucket.s3_content_bucket.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_bucket_versioning" "s3_content_bucket_versioning" {
   bucket = aws_s3_bucket.s3_content_bucket.id
   versioning_configuration {


### PR DESCRIPTION
AWS no longer recommends using ACLs

> For the majority of modern use cases in S3, we recommend that you keep ACLs disabled by applying the Bucket owner enforced setting and using your bucket policy to share data with users outside of your account as needed. This approach simplifies permissions management. You can disable ACLs on both newly created and already existing buckets. For newly created buckets, ACLs are disabled by default. In the case of an existing bucket that already has objects in it, after you disable ACLs, the object and bucket ACLs are no longer part of an access evaluation, and access is granted or denied on the basis of policies. For existing buckets, you can re-enable ACLs at any time after you disable them, and your preexisting bucket and object ACLs are restored.

https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html